### PR TITLE
Fix invalid type issue for handling struct slice

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -252,8 +252,8 @@ func (ctx *Ctx) findInterfaceImplementers(ut *types.Interface) []types.Type {
 
 func (ctx *Ctx) run() *File {
 	f := NewFile(ctx.thisPkg.Name)
-	ctx.expandType(ctx.t, nil, false, nil, expandSlot{f: f})
-	ctx.flattenType(ctx.t, nil, false, nil, flattenSlot{f: f})
+	ctx.expandType(ctx.t, nil, false, nil, expandSlot{f: f}, false)
+	ctx.flattenType(ctx.t, nil, false, nil, flattenSlot{f: f}, false)
 	return f
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -15,8 +15,9 @@ func TestAll(t *testing.T) {
 	resultBaseDir := filepath.Join(pwd, "testdata", "results")
 
 	cases := []struct {
-		typ   string
-		flags Flags
+		typ          string
+		expectFolder string
+		flags        Flags
 	}{
 		{
 			typ: "TypePrimaryCollection",
@@ -151,6 +152,18 @@ func TestAll(t *testing.T) {
 		{
 			typ: "TypeNamedInterface",
 		},
+		{
+			typ:          "[]TypeS1",
+			expectFolder: "TypeS1_Slice",
+		},
+		{
+			typ: "[]TypePrimaryPtrCollection",
+			expectFolder: "TypePrimaryPtrCollection_Slice",
+		},
+		{
+			typ: "[]TypeNamedStructCollection",
+			expectFolder: "TypeNamedStructCollection_Slice",
+		},
 	}
 
 	for _, c := range cases {
@@ -166,7 +179,11 @@ func TestAll(t *testing.T) {
 		f := ctx.run()
 		require.NoError(t, f.Render(buf), c.typ)
 
-		expectFile := filepath.Join(resultBaseDir, c.typ, "main.go")
+		expectFolder := c.expectFolder
+		if expectFolder == "" {
+			expectFolder = c.typ
+		}
+		expectFile := filepath.Join(resultBaseDir, expectFolder, "main.go")
 		expectByte, _ := os.ReadFile(expectFile)
 		require.Equal(t, string(expectByte), buf.String(), c.typ)
 	}

--- a/testdata/results/TypeNamedStructCollection_Slice/go.mod
+++ b/testdata/results/TypeNamedStructCollection_Slice/go.mod
@@ -1,0 +1,7 @@
+module result
+
+require types v0.0.0
+
+replace types => ./../../types
+
+go 1.16

--- a/testdata/results/TypeNamedStructCollection_Slice/main.go
+++ b/testdata/results/TypeNamedStructCollection_Slice/main.go
@@ -1,0 +1,50 @@
+package types
+
+import types "types"
+
+func expandTypeNamedStructCollectionSlice(input []interface{}) []types.TypeNamedStructCollection {
+	if len(input) == 0 {
+		return nil
+	}
+	output := make([]types.TypeNamedStructCollection, 0)
+	for _, elem := range input {
+		elem := elem.(map[string]interface{})
+		output = append(output, types.TypeNamedStructCollection{
+			S1: expandTypeS1(elem["s_1"].([]interface{})),
+			S2: expandTypeS2(elem["s_2"].([]interface{})),
+		})
+	}
+	return output
+}
+func expandTypeS1(input []interface{}) types.TypeS1 {
+	if len(input) == 0 || input[0] == nil {
+		return types.TypeS1{}
+	}
+	b := input[0].(map[string]interface{})
+	output := types.TypeS1{I: b["i"].(int)}
+	return output
+}
+func expandTypeS2(input []interface{}) types.TypeS2 {
+	if len(input) == 0 || input[0] == nil {
+		return types.TypeS2{}
+	}
+	b := input[0].(map[string]interface{})
+	output := types.TypeS2{S: b["s"].(string)}
+	return output
+}
+func flattenTypeNamedStructCollectionSlice(input []types.TypeNamedStructCollection) []interface{} {
+	output := make([]interface{}, 0)
+	for _, elem := range input {
+		output = append(output, map[string]interface{}{
+			"s_1": flattenTypeS1(elem.S1),
+			"s_2": flattenTypeS2(elem.S2),
+		})
+	}
+	return output
+}
+func flattenTypeS1(input types.TypeS1) []interface{} {
+	return []interface{}{map[string]interface{}{"i": input.I}}
+}
+func flattenTypeS2(input types.TypeS2) []interface{} {
+	return []interface{}{map[string]interface{}{"s": input.S}}
+}

--- a/testdata/results/TypeNamedStructSliceCollection/main.go
+++ b/testdata/results/TypeNamedStructSliceCollection/main.go
@@ -21,16 +21,9 @@ func expandTypeS1Slice(input []interface{}) []types.TypeS1 {
 	}
 	output := make([]types.TypeS1, 0)
 	for _, elem := range input {
-		output = append(output, expandTypeS1(elem.([]interface{})))
+		elem := elem.(map[string]interface{})
+		output = append(output, types.TypeS1{I: elem["i"].(int)})
 	}
-	return output
-}
-func expandTypeS1(input []interface{}) types.TypeS1 {
-	if len(input) == 0 || input[0] == nil {
-		return types.TypeS1{}
-	}
-	b := input[0].(map[string]interface{})
-	output := types.TypeS1{I: b["i"].(int)}
 	return output
 }
 func expandTypeS1SlicePtr(input []interface{}) *[]types.TypeS1 {
@@ -39,7 +32,8 @@ func expandTypeS1SlicePtr(input []interface{}) *[]types.TypeS1 {
 	}
 	output := make([]types.TypeS1, 0)
 	for _, elem := range input {
-		output = append(output, expandTypeS1(elem.([]interface{})))
+		elem := elem.(map[string]interface{})
+		output = append(output, types.TypeS1{I: elem["i"].(int)})
 	}
 	return &output
 }
@@ -49,16 +43,9 @@ func expandTypeS1PtrSlice(input []interface{}) []*types.TypeS1 {
 	}
 	output := make([]*types.TypeS1, 0)
 	for _, elem := range input {
-		output = append(output, expandTypeS1Ptr(elem.([]interface{})))
+		elem := elem.(map[string]interface{})
+		output = append(output, &types.TypeS1{I: elem["i"].(int)})
 	}
-	return output
-}
-func expandTypeS1Ptr(input []interface{}) *types.TypeS1 {
-	if len(input) == 0 || input[0] == nil {
-		return nil
-	}
-	b := input[0].(map[string]interface{})
-	output := &types.TypeS1{I: b["i"].(int)}
 	return output
 }
 func expandTypeS1PtrSlicePtr(input []interface{}) *[]*types.TypeS1 {
@@ -67,7 +54,8 @@ func expandTypeS1PtrSlicePtr(input []interface{}) *[]*types.TypeS1 {
 	}
 	output := make([]*types.TypeS1, 0)
 	for _, elem := range input {
-		output = append(output, expandTypeS1Ptr(elem.([]interface{})))
+		elem := elem.(map[string]interface{})
+		output = append(output, &types.TypeS1{I: elem["i"].(int)})
 	}
 	return &output
 }
@@ -82,12 +70,9 @@ func flattenTypeNamedStructSliceCollection(input types.TypeNamedStructSliceColle
 func flattenTypeS1Slice(input []types.TypeS1) []interface{} {
 	output := make([]interface{}, 0)
 	for _, elem := range input {
-		output = append(output, flattenTypeS1(elem))
+		output = append(output, map[string]interface{}{"i": elem.I})
 	}
 	return output
-}
-func flattenTypeS1(input types.TypeS1) []interface{} {
-	return []interface{}{map[string]interface{}{"i": input.I}}
 }
 func flattenTypeS1SlicePtr(input *[]types.TypeS1) []interface{} {
 	if input == nil {
@@ -95,22 +80,19 @@ func flattenTypeS1SlicePtr(input *[]types.TypeS1) []interface{} {
 	}
 	output := make([]interface{}, 0)
 	for _, elem := range *input {
-		output = append(output, flattenTypeS1(elem))
+		output = append(output, map[string]interface{}{"i": elem.I})
 	}
 	return output
 }
 func flattenTypeS1PtrSlice(input []*types.TypeS1) []interface{} {
 	output := make([]interface{}, 0)
 	for _, elem := range input {
-		output = append(output, flattenTypeS1Ptr(elem))
+		if input == nil {
+			continue
+		}
+		output = append(output, map[string]interface{}{"i": elem.I})
 	}
 	return output
-}
-func flattenTypeS1Ptr(input *types.TypeS1) []interface{} {
-	if input == nil {
-		return []interface{}{}
-	}
-	return []interface{}{map[string]interface{}{"i": input.I}}
 }
 func flattenTypeS1PtrSlicePtr(input *[]*types.TypeS1) []interface{} {
 	if input == nil {
@@ -118,7 +100,10 @@ func flattenTypeS1PtrSlicePtr(input *[]*types.TypeS1) []interface{} {
 	}
 	output := make([]interface{}, 0)
 	for _, elem := range *input {
-		output = append(output, flattenTypeS1Ptr(elem))
+		if input == nil {
+			continue
+		}
+		output = append(output, map[string]interface{}{"i": elem.I})
 	}
 	return output
 }

--- a/testdata/results/TypePrimaryPtrCollection_Slice/go.mod
+++ b/testdata/results/TypePrimaryPtrCollection_Slice/go.mod
@@ -1,0 +1,7 @@
+module result
+
+require types v0.0.0
+
+replace types => ./../../types
+
+go 1.16

--- a/testdata/results/TypePrimaryPtrCollection_Slice/main.go
+++ b/testdata/results/TypePrimaryPtrCollection_Slice/main.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	types "types"
+	utils "types/utils"
+)
+
+func expandTypePrimaryPtrCollectionSlice(input []interface{}) []types.TypePrimaryPtrCollection {
+	if len(input) == 0 {
+		return nil
+	}
+	output := make([]types.TypePrimaryPtrCollection, 0)
+	for _, elem := range input {
+		elem := elem.(map[string]interface{})
+		output = append(output, types.TypePrimaryPtrCollection{
+			PtrBool:  utils.Bool(elem["ptr_bool"].(bool)),
+			PtrFloat: utils.Float64(elem["ptr_float"].(float64)),
+			PtrInt:   utils.Int(elem["ptr_int"].(int)),
+			PtrStr:   utils.String(elem["ptr_str"].(string)),
+		})
+	}
+	return output
+}
+func flattenTypePrimaryPtrCollectionSlice(input []types.TypePrimaryPtrCollection) []interface{} {
+	output := make([]interface{}, 0)
+	for _, elem := range input {
+		var ptrBool bool
+		if elem.PtrBool != nil {
+			ptrBool = *elem.PtrBool
+		}
+		var ptrInt int
+		if elem.PtrInt != nil {
+			ptrInt = *elem.PtrInt
+		}
+		var ptrStr string
+		if elem.PtrStr != nil {
+			ptrStr = *elem.PtrStr
+		}
+		var ptrFloat float64
+		if elem.PtrFloat != nil {
+			ptrFloat = *elem.PtrFloat
+		}
+		output = append(output, map[string]interface{}{
+			"ptr_bool":  ptrBool,
+			"ptr_float": ptrFloat,
+			"ptr_int":   ptrInt,
+			"ptr_str":   ptrStr,
+		})
+	}
+	return output
+}

--- a/testdata/results/TypeS1_Slice/go.mod
+++ b/testdata/results/TypeS1_Slice/go.mod
@@ -1,0 +1,7 @@
+module result
+
+require types v0.0.0
+
+replace types => ./../../types
+
+go 1.16

--- a/testdata/results/TypeS1_Slice/main.go
+++ b/testdata/results/TypeS1_Slice/main.go
@@ -2,18 +2,18 @@ package types
 
 import types "types"
 
-func expandTypeNamedStructSliceAlias(input []interface{}) types.TypeNamedStructSliceAlias {
+func expandTypeS1Slice(input []interface{}) []types.TypeS1 {
 	if len(input) == 0 {
 		return nil
 	}
-	output := make(types.TypeNamedStructSliceAlias, 0)
+	output := make([]types.TypeS1, 0)
 	for _, elem := range input {
 		elem := elem.(map[string]interface{})
 		output = append(output, types.TypeS1{I: elem["i"].(int)})
 	}
 	return output
 }
-func flattenTypeNamedStructSliceAliasSlice(input types.TypeNamedStructSliceAlias) []interface{} {
+func flattenTypeS1Slice(input []types.TypeS1) []interface{} {
 	output := make([]interface{}, 0)
 	for _, elem := range input {
 		output = append(output, map[string]interface{}{"i": elem.I})

--- a/testdata/types/types.go
+++ b/testdata/types/types.go
@@ -259,4 +259,5 @@ func (s TypeS1) Foo() {}
 func (s *TypeS2) Foo() {}
 
 type TypeNamedInterfaceSlice []TypeNamedInterface
+
 type TypeNamedInterfaceMap map[string]TypeNamedInterface


### PR DESCRIPTION
Now the type should correspond to the terraform internal representation.
Also, in case of struct slice, we will inline the expand/flatten code to
the slice level.